### PR TITLE
Add shareable links for dashboard history items

### DIFF
--- a/app/api/share/[shareId]/route.ts
+++ b/app/api/share/[shareId]/route.ts
@@ -7,12 +7,16 @@ const supabaseAdmin = supabaseUrl && supabaseServiceKey
   ? createClient(supabaseUrl, supabaseServiceKey)
   : null;
 
-export async function GET(_req: NextRequest, { params }: { params: { shareId: string } }) {
+export async function GET(
+  _req: NextRequest,
+  context: { params?: Promise<{ shareId?: string }> }
+) {
   if (!supabaseAdmin) {
     return NextResponse.json({ ok: false, error: 'Supabase is not configured.' }, { status: 500 });
   }
 
-  const shareId = params.shareId;
+  const resolvedParams = context.params ? await context.params : undefined;
+  const shareId = resolvedParams?.shareId;
   if (!shareId) {
     return NextResponse.json({ ok: false, error: 'Missing share ID.' }, { status: 400 });
   }

--- a/app/api/share/[shareId]/route.ts
+++ b/app/api/share/[shareId]/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+const supabaseAdmin = supabaseUrl && supabaseServiceKey
+  ? createClient(supabaseUrl, supabaseServiceKey)
+  : null;
+
+export async function GET(_req: NextRequest, { params }: { params: { shareId: string } }) {
+  if (!supabaseAdmin) {
+    return NextResponse.json({ ok: false, error: 'Supabase is not configured.' }, { status: 500 });
+  }
+
+  const shareId = params.shareId;
+  if (!shareId) {
+    return NextResponse.json({ ok: false, error: 'Missing share ID.' }, { status: 400 });
+  }
+
+  try {
+    const { data, error } = await supabaseAdmin
+      .from('public_shares')
+      .select('item_type, title, markdown, cards, created_at')
+      .eq('share_id', shareId)
+      .limit(1)
+      .maybeSingle();
+
+    if (error) {
+      console.error('Failed to load shared item:', error);
+      return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
+    }
+
+    if (!data) {
+      return NextResponse.json({ ok: false, error: 'Share link not found.' }, { status: 404 });
+    }
+
+    return NextResponse.json({ ok: true, share: data });
+  } catch (error) {
+    console.error('Unexpected error fetching shared item:', error);
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/app/api/share/[shareId]/route.ts
+++ b/app/api/share/[shareId]/route.ts
@@ -9,14 +9,20 @@ const supabaseAdmin = supabaseUrl && supabaseServiceKey
 
 export async function GET(
   _req: NextRequest,
-  context: { params?: Promise<{ shareId?: string }> }
+  { params }: { params: Promise<{ shareId: string }> }
 ) {
   if (!supabaseAdmin) {
     return NextResponse.json({ ok: false, error: 'Supabase is not configured.' }, { status: 500 });
   }
 
-  const resolvedParams = context.params ? await context.params : undefined;
-  const shareId = resolvedParams?.shareId;
+  let shareId: string | undefined;
+  try {
+    const resolvedParams = await params;
+    shareId = resolvedParams?.shareId;
+  } catch (error) {
+    console.error('Failed to resolve share params:', error);
+  }
+
   if (!shareId) {
     return NextResponse.json({ ok: false, error: 'Missing share ID.' }, { status: 400 });
   }

--- a/app/api/share/route.ts
+++ b/app/api/share/route.ts
@@ -1,0 +1,189 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { randomBytes } from 'node:crypto';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+const supabaseAdmin = supabaseUrl && supabaseServiceKey
+  ? createClient(supabaseUrl, supabaseServiceKey)
+  : null;
+
+type ShareItemType = 'mindmap' | 'flashcards';
+type SharedFlashcard = { question: string; answer: string };
+
+type MindmapRow = {
+  id: string;
+  user_id: string;
+  title: string | null;
+  markdown: string | null;
+};
+
+type FlashcardsRow = {
+  id: string;
+  user_id: string;
+  title: string | null;
+  markdown: string | null;
+  cards: SharedFlashcard[] | null;
+};
+
+type ShareRow = {
+  id: string;
+  share_id: string;
+};
+
+interface SharePayload {
+  type?: string;
+  id?: string;
+}
+
+const isValidType = (value: string): value is ShareItemType =>
+  value === 'mindmap' || value === 'flashcards';
+
+async function getUserIdFromAuthHeader(req: NextRequest): Promise<string | null> {
+  if (!supabaseAdmin) return null;
+  try {
+    const authHeader = req.headers.get('authorization') || '';
+    const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : '';
+    if (!token) return null;
+    const { data } = await supabaseAdmin.auth.getUser(token);
+    return data.user?.id ?? null;
+  } catch (error) {
+    console.error('Failed to extract user from auth header:', error);
+    return null;
+  }
+}
+
+function generateShareId() {
+  return randomBytes(9).toString('hex');
+}
+
+export async function POST(req: NextRequest) {
+  if (!supabaseAdmin) {
+    return NextResponse.json({ ok: false, error: 'Supabase is not configured.' }, { status: 500 });
+  }
+
+  let payload: SharePayload;
+  try {
+    payload = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: 'Invalid request body.' }, { status: 400 });
+  }
+
+  const type = typeof payload.type === 'string' ? payload.type.trim() : '';
+  const id = typeof payload.id === 'string' ? payload.id.trim() : '';
+
+  if (!isValidType(type) || !id) {
+    return NextResponse.json({ ok: false, error: 'Invalid share request.' }, { status: 400 });
+  }
+
+  const userId = await getUserIdFromAuthHeader(req);
+  if (!userId) {
+    return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    if (type === 'mindmap') {
+      const { data: record, error: fetchError } = await supabaseAdmin
+        .from('mindmaps')
+        .select<MindmapRow>('id, user_id, title, markdown')
+        .eq('id', id)
+        .limit(1)
+        .single();
+
+      if (fetchError || !record || record.user_id !== userId) {
+        return NextResponse.json({ ok: false, error: 'Item not found.' }, { status: 404 });
+      }
+
+      const { data: existingShare, error: existingError } = await supabaseAdmin
+        .from('public_shares')
+        .select<ShareRow>('id, share_id')
+        .eq('item_type', type)
+        .eq('item_id', id)
+        .limit(1)
+        .maybeSingle();
+
+      if (existingError) {
+        throw existingError;
+      }
+
+      if (existingShare) {
+        await supabaseAdmin
+          .from('public_shares')
+          .update({
+            title: record.title ?? null,
+            markdown: record.markdown ?? null,
+            cards: null,
+          })
+          .eq('id', existingShare.id);
+
+        return NextResponse.json({ ok: true, shareId: existingShare.share_id });
+      }
+
+      const shareId = generateShareId();
+      await supabaseAdmin.from('public_shares').insert({
+        user_id: userId,
+        item_type: type,
+        item_id: id,
+        title: record.title ?? null,
+        markdown: record.markdown ?? null,
+        cards: null,
+        share_id: shareId,
+      });
+
+      return NextResponse.json({ ok: true, shareId });
+    }
+
+    const { data: record, error: fetchError } = await supabaseAdmin
+      .from('flashcards')
+      .select<FlashcardsRow>('id, user_id, title, markdown, cards')
+      .eq('id', id)
+      .limit(1)
+      .single();
+
+    if (fetchError || !record || record.user_id !== userId) {
+      return NextResponse.json({ ok: false, error: 'Item not found.' }, { status: 404 });
+    }
+
+    const { data: existingShare, error: existingError } = await supabaseAdmin
+      .from('public_shares')
+      .select<ShareRow>('id, share_id')
+      .eq('item_type', type)
+      .eq('item_id', id)
+      .limit(1)
+      .maybeSingle();
+
+    if (existingError) {
+      throw existingError;
+    }
+
+    if (existingShare) {
+      await supabaseAdmin
+        .from('public_shares')
+        .update({
+          title: record.title ?? null,
+          markdown: record.markdown ?? null,
+          cards: record.cards ?? null,
+        })
+        .eq('id', existingShare.id);
+
+      return NextResponse.json({ ok: true, shareId: existingShare.share_id });
+    }
+
+    const shareId = generateShareId();
+    await supabaseAdmin.from('public_shares').insert({
+      user_id: userId,
+      item_type: type,
+      item_id: id,
+      title: record.title ?? null,
+      markdown: record.markdown ?? null,
+      cards: record.cards ?? null,
+      share_id: shareId,
+    });
+
+    return NextResponse.json({ ok: true, shareId });
+  } catch (error) {
+    console.error('Failed to create share link:', error);
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/app/share/[shareId]/page.tsx
+++ b/app/share/[shareId]/page.tsx
@@ -1,0 +1,147 @@
+import { notFound } from 'next/navigation';
+import { createClient } from '@supabase/supabase-js';
+import Image from 'next/image';
+import Link from 'next/link';
+import EmbeddedMindMap from '@/components/EmbeddedMindMap';
+import CogniGuideLogo from '../../../CogniGuide_logo.png';
+
+export const dynamic = 'force-dynamic';
+
+type SharedFlashcard = { question: string; answer: string };
+
+type ShareRecord = {
+  item_type: 'mindmap' | 'flashcards';
+  title: string | null;
+  markdown: string | null;
+  cards: SharedFlashcard[] | null;
+  created_at: string | null;
+};
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+
+async function getShareRecord(shareId: string): Promise<ShareRecord | null> {
+  if (!supabaseUrl || !supabaseServiceKey) {
+    return null;
+  }
+
+  const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey);
+  const { data, error } = await supabaseAdmin
+    .from('public_shares')
+    .select('item_type, title, markdown, cards, created_at')
+    .eq('share_id', shareId)
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    console.error('Failed to load share record:', error);
+    return null;
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  return data as ShareRecord;
+}
+
+function formatShareTitle(record: ShareRecord): string {
+  if (record.title && record.title.trim().length > 0) {
+    return record.title.trim();
+  }
+  return record.item_type === 'mindmap' ? 'Mind map' : 'Flashcards';
+}
+
+function FlashcardsList({ cards }: { cards: SharedFlashcard[] }) {
+  if (!cards || cards.length === 0) {
+    return (
+      <div className="rounded-2xl border border-dashed bg-muted/40 p-8 text-center text-sm text-muted-foreground">
+        No flashcards to display.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {cards.map((card, index) => (
+        <div key={`${index}-${card.question.slice(0, 12)}`} className="rounded-2xl border bg-background p-5 shadow-sm">
+          <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Question {index + 1}
+          </div>
+          <h3 className="mt-2 text-base font-semibold text-foreground whitespace-pre-wrap">{card.question}</h3>
+          <div className="mt-4 rounded-xl border bg-muted/40 px-4 py-3 text-sm text-foreground whitespace-pre-wrap">
+            {card.answer}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default async function SharePage({ params }: { params: { shareId: string } }) {
+  const record = await getShareRecord(params.shareId);
+  if (!record) {
+    notFound();
+  }
+
+  const title = formatShareTitle(record);
+  const createdAt = record.created_at ? new Date(record.created_at) : null;
+
+  return (
+    <div className="min-h-screen bg-muted/20 text-foreground">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-10 sm:py-14">
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <Link href="/" className="inline-flex items-center gap-2 text-foreground">
+            <Image src={CogniGuideLogo} alt="CogniGuide" width={40} height={40} className="h-10 w-10" />
+            <span className="text-xl font-semibold">CogniGuide</span>
+          </Link>
+          <Link
+            href="/"
+            className="inline-flex items-center justify-center rounded-full bg-gradient-primary px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-gradient-primary-hover"
+          >
+            Try CogniGuide for free
+          </Link>
+        </header>
+
+        <div className="rounded-3xl border bg-background/95 p-6 shadow-xl sm:p-10">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h1 className="text-2xl font-bold sm:text-3xl">{title}</h1>
+              {createdAt && (
+                <p className="text-sm text-muted-foreground">
+                  Shared on {createdAt.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })}
+                </p>
+              )}
+            </div>
+            <span className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-1 text-sm font-medium text-primary">
+              {record.item_type === 'mindmap' ? 'Mind Map' : 'Flashcards'}
+            </span>
+          </div>
+
+          <div className="mt-8">
+            {record.item_type === 'mindmap' ? (
+              <div className="h-[540px] w-full overflow-hidden rounded-2xl border bg-muted/30 p-4">
+                {record.markdown ? (
+                  <EmbeddedMindMap markdown={record.markdown} />
+                ) : (
+                  <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                    Mind map content is unavailable.
+                  </div>
+                )}
+              </div>
+            ) : (
+              <FlashcardsList cards={record.cards ?? []} />
+            )}
+          </div>
+        </div>
+
+        <footer className="mt-6 flex flex-col items-center gap-2 text-center text-sm text-muted-foreground">
+          <p>Powered by CogniGuide — create mind maps and flashcards in seconds.</p>
+          <Link href="/" className="text-primary underline-offset-4 hover:underline">
+            Start your own study session
+          </Link>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/app/share/[shareId]/page.tsx
+++ b/app/share/[shareId]/page.tsx
@@ -78,8 +78,20 @@ function FlashcardsList({ cards }: { cards: SharedFlashcard[] }) {
   );
 }
 
-export default async function SharePage({ params }: { params: { shareId: string } }) {
-  const record = await getShareRecord(params.shareId);
+export default async function SharePage({ params }: { params: Promise<{ shareId: string }> }) {
+  let shareId: string | undefined;
+  try {
+    const resolvedParams = await params;
+    shareId = resolvedParams?.shareId;
+  } catch (error) {
+    console.error('Failed to resolve share params:', error);
+  }
+
+  if (!shareId) {
+    notFound();
+  }
+
+  const record = await getShareRecord(shareId);
   if (!record) {
     notFound();
   }

--- a/app/share/[shareId]/page.tsx
+++ b/app/share/[shareId]/page.tsx
@@ -78,10 +78,14 @@ function FlashcardsList({ cards }: { cards: SharedFlashcard[] }) {
   );
 }
 
-export default async function SharePage({ params }: { params: Promise<{ shareId: string }> }) {
+type SharePageProps = {
+  params: Promise<{ shareId: string }>;
+};
+
+export default async function SharePage(props: SharePageProps) {
   let shareId: string | undefined;
   try {
-    const resolvedParams = await params;
+    const resolvedParams = await props.params;
     shareId = resolvedParams?.shareId;
   } catch (error) {
     console.error('Failed to resolve share params:', error);

--- a/supabase/migrations/20250201000000_create_public_shares.sql
+++ b/supabase/migrations/20250201000000_create_public_shares.sql
@@ -1,0 +1,15 @@
+create table if not exists public.public_shares (
+    id uuid primary key default gen_random_uuid(),
+    share_id text not null unique,
+    user_id uuid references auth.users(id) on delete cascade,
+    item_type text not null check (item_type in ('mindmap', 'flashcards')),
+    item_id uuid not null,
+    title text,
+    markdown text,
+    cards jsonb,
+    created_at timestamptz not null default timezone('utc', now())
+);
+
+create unique index if not exists public_shares_item_unique on public.public_shares (item_type, item_id);
+
+alter table public.public_shares enable row level security;


### PR DESCRIPTION
## Summary
- add a share action to history item menus that opens a modal for generating and copying public links
- implement Supabase-backed API endpoints and a public share page for viewing shared mind maps or flashcards without authentication
- introduce a `public_shares` table migration to persist shareable snapshots for each item type

## Testing
- pnpm lint *(fails: existing lint errors across the repository, including numerous legacy `any` usages unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d03c7c6094832590f07c7106820d0c