### PR TITLE
Add public sharing flow for mind maps and flashcards

### DIFF
--- a/app/api/share-link/route.ts
+++ b/app/api/share-link/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { createShareToken, type ShareableResourceType } from '@/lib/share-links';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+
+const supabaseAdmin = supabaseUrl && supabaseServiceKey
+  ? createClient(supabaseUrl, supabaseServiceKey)
+  : null;
+
+async function getUserIdFromAuthHeader(req: NextRequest): Promise<string | null> {
+  try {
+    const authHeader = req.headers.get('authorization') || '';
+    const token = authHeader.startsWith('Bearer ')
+      ? authHeader.slice(7)
+      : '';
+    if (!token || !supabaseAdmin) return null;
+    const { data } = await supabaseAdmin.auth.getUser(token);
+    return data.user?.id || null;
+  } catch {
+    return null;
+  }
+}
+
+function validateType(value: unknown): value is ShareableResourceType {
+  return value === 'mindmap' || value === 'flashcards';
+}
+
+function isOwnerRow(value: unknown): value is { id: string; user_id: string } {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return typeof record.id === 'string' && typeof record.user_id === 'string';
+}
+
+export async function POST(req: NextRequest) {
+  if (!supabaseAdmin) {
+    return NextResponse.json({ ok: false, error: 'Sharing is not configured.' }, { status: 500 });
+  }
+
+  try {
+    const userId = await getUserIdFromAuthHeader(req);
+    if (!userId) {
+      return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await req.json().catch(() => null);
+    const itemId = typeof body?.itemId === 'string' ? body.itemId : null;
+    const itemType = body?.itemType;
+
+    if (!validateType(itemType) || !itemId) {
+      return NextResponse.json({ ok: false, error: 'Invalid request.' }, { status: 400 });
+    }
+
+    const table = itemType === 'mindmap' ? 'mindmaps' : 'flashcards';
+    const { data, error } = await supabaseAdmin
+      .from(table)
+      .select('id, user_id')
+      .eq('id', itemId)
+      .limit(1)
+      .maybeSingle();
+
+    if (error || !data || !isOwnerRow(data)) {
+      return NextResponse.json({ ok: false, error: 'Item not found.' }, { status: 404 });
+    }
+
+    if (data.user_id !== userId) {
+      return NextResponse.json({ ok: false, error: 'You do not have permission to share this item.' }, { status: 403 });
+    }
+
+    const token = createShareToken(itemType, itemId);
+    const origin = req.nextUrl?.origin || req.headers.get('origin') || process.env.NEXT_PUBLIC_APP_URL || '';
+    const url = origin
+      ? `${origin.replace(/\/$/, '')}/share/${itemType}/${token}`
+      : `/share/${itemType}/${token}`;
+
+    return NextResponse.json({ ok: true, token, url });
+  } catch (error) {
+    console.error('Failed to create share link:', error);
+    return NextResponse.json({ ok: false, error: 'Unable to create share link.' }, { status: 500 });
+  }
+}

--- a/app/share/[type]/[token]/page.tsx
+++ b/app/share/[type]/[token]/page.tsx
@@ -1,0 +1,87 @@
+import { notFound } from 'next/navigation';
+import { createClient } from '@supabase/supabase-js';
+import ShareViewer from '@/components/ShareViewer';
+import { verifyShareToken } from '@/lib/share-links';
+
+export const dynamic = 'force-dynamic';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+
+const supabaseAdmin = supabaseUrl && supabaseServiceKey
+  ? createClient(supabaseUrl, supabaseServiceKey)
+  : null;
+
+type SharePageProps = {
+  params: { type: string; token: string };
+};
+
+export default async function SharePage({ params }: SharePageProps) {
+  const { type, token } = params;
+  if (type !== 'mindmap' && type !== 'flashcards') {
+    notFound();
+  }
+
+  if (!supabaseAdmin) {
+    return (
+      <div className="min-h-screen flex items-center justify-center px-6">
+        <div className="max-w-md text-center space-y-3">
+          <h1 className="text-2xl font-semibold">Sharing Unavailable</h1>
+          <p className="text-muted-foreground text-sm">
+            Public sharing is not configured for this deployment.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const decoded = verifyShareToken(token);
+  if (!decoded || decoded.type !== type) {
+    notFound();
+  }
+
+  const table = decoded.type === 'mindmap' ? 'mindmaps' : 'flashcards';
+  const columns = decoded.type === 'mindmap'
+    ? 'markdown, title, created_at'
+    : 'cards, title, created_at';
+
+  const { data } = await supabaseAdmin
+    .from(table)
+    .select(columns)
+    .eq('id', decoded.id)
+    .single();
+
+  if (!data) {
+    notFound();
+  }
+
+  if (decoded.type === 'mindmap') {
+    const record = data as Record<string, unknown>;
+    const markdown = record.markdown;
+    if (typeof markdown !== 'string' || markdown.length === 0) {
+      notFound();
+    }
+    const title = typeof record.title === 'string' || record.title === null ? record.title : null;
+    return <ShareViewer type="mindmap" markdown={markdown} title={title} />;
+  }
+
+  const record = data as Record<string, unknown>;
+  let cardsData = record.cards;
+  if (typeof cardsData === 'string') {
+    try {
+      cardsData = JSON.parse(cardsData);
+    } catch {
+      cardsData = [];
+    }
+  }
+
+  const cards = Array.isArray(cardsData) ? (cardsData as unknown[]) : [];
+  const safeCards = cards.filter((card): card is { question: string; answer: string } => {
+    if (typeof card !== 'object' || card === null) return false;
+    const value = card as Record<string, unknown>;
+    return typeof value.question === 'string' && typeof value.answer === 'string';
+  });
+  const title = typeof record.title === 'string' || record.title === null ? record.title : null;
+
+  return <ShareViewer type="flashcards" cards={safeCards} title={title} deckId={decoded.id} />;
+}

--- a/components/ShareViewer.tsx
+++ b/components/ShareViewer.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import MindMapModal from '@/components/MindMapModal';
+import FlashcardsModal, { type Flashcard } from '@/components/FlashcardsModal';
+
+type ShareViewerProps =
+  | {
+      type: 'mindmap';
+      markdown: string;
+      title?: string | null;
+    }
+  | {
+      type: 'flashcards';
+      cards: Flashcard[];
+      title?: string | null;
+      deckId?: string;
+    };
+
+export default function ShareViewer(props: ShareViewerProps) {
+  const router = useRouter();
+  const [isOpen, setIsOpen] = useState(true);
+
+  useEffect(() => {
+    if (!isOpen) {
+      router.push('/');
+    }
+  }, [isOpen, router]);
+
+  if (props.type === 'mindmap') {
+    return (
+      <MindMapModal
+        markdown={isOpen ? props.markdown : null}
+        onClose={() => setIsOpen(false)}
+      />
+    );
+  }
+
+  return (
+    <FlashcardsModal
+      open={isOpen}
+      title={props.title}
+      cards={props.cards}
+      isGenerating={false}
+      error={null}
+      onClose={() => setIsOpen(false)}
+      deckId={props.deckId}
+    />
+  );
+}

--- a/lib/share-links.ts
+++ b/lib/share-links.ts
@@ -1,0 +1,76 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+
+export type ShareableResourceType = 'mindmap' | 'flashcards';
+
+interface SharePayload {
+  type: ShareableResourceType;
+  id: string;
+}
+
+function getSecret(): string {
+  const secret = process.env.SHARE_LINK_SECRET || process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!secret) {
+    throw new Error('Share link secret is not configured. Set SHARE_LINK_SECRET or SUPABASE_SERVICE_ROLE_KEY.');
+  }
+  return secret;
+}
+
+function base64UrlEncode(buffer: Buffer): string {
+  return buffer
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+}
+
+function base64UrlDecode(input: string): Buffer {
+  const normalized = input.replace(/-/g, '+').replace(/_/g, '/');
+  const padLength = (4 - (normalized.length % 4)) % 4;
+  const padded = normalized + '='.repeat(padLength);
+  return Buffer.from(padded, 'base64');
+}
+
+function signPayload(payload: string): Buffer {
+  const secret = getSecret();
+  return createHmac('sha256', secret).update(payload).digest();
+}
+
+export function createShareToken(type: ShareableResourceType, id: string): string {
+  if (!id) {
+    throw new Error('Cannot create share token without an id.');
+  }
+  const payload: SharePayload = { type, id };
+  const payloadBuffer = Buffer.from(JSON.stringify(payload), 'utf8');
+  const payloadEncoded = base64UrlEncode(payloadBuffer);
+  const signature = signPayload(payloadEncoded);
+  const signatureEncoded = base64UrlEncode(signature);
+  return `${payloadEncoded}.${signatureEncoded}`;
+}
+
+export function verifyShareToken(token: string): SharePayload | null {
+  if (!token || typeof token !== 'string') return null;
+  const parts = token.split('.');
+  if (parts.length !== 2) return null;
+  const [payloadEncoded, signatureEncoded] = parts;
+  if (!payloadEncoded || !signatureEncoded) return null;
+
+  try {
+    const expectedSignature = signPayload(payloadEncoded);
+    const providedSignature = base64UrlDecode(signatureEncoded);
+    if (expectedSignature.length !== providedSignature.length) return null;
+    if (!timingSafeEqual(expectedSignature, providedSignature)) return null;
+
+    const payloadBuffer = base64UrlDecode(payloadEncoded);
+    const payloadJson = payloadBuffer.toString('utf8');
+    const parsed = JSON.parse(payloadJson) as Partial<SharePayload>;
+    if (!parsed || typeof parsed !== 'object') return null;
+    const { type, id } = parsed;
+    if ((type !== 'mindmap' && type !== 'flashcards') || typeof id !== 'string' || !id) {
+      return null;
+    }
+    return { type, id };
+  } catch (error) {
+    console.error('Failed to verify share token:', error);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add share button to dashboard history items with modal for creating and copying public links
- introduce signed share-token helper and API endpoint for generating shareable URLs
- add public share page and client viewer that renders shared mind maps or flashcard decks without authentication

## Testing
- pnpm lint *(fails: pre-existing lint violations across project)*

------
https://chatgpt.com/codex/tasks/task_e_68d144d1bf388325a86dda969e8cd477