### PR TITLE
Ensure share modal overlays study modals

### DIFF
--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { supabase, MindmapRecord, FlashcardsRecord } from '@/lib/supabaseClient';
@@ -133,6 +134,8 @@ export default function DashboardClient() {
   const [user, setUser] = useState<SessionUser | null>(null);
   const [loading, setLoading] = useState(true);
   const [markdown, setMarkdown] = useState<string | null>(null);
+  const [activeMindMapId, setActiveMindMapId] = useState<string | null>(null);
+  const [activeMindMapTitle, setActiveMindMapTitle] = useState<string | null>(null);
   // Full flashcards list for spaced repetition prefetching
   const [flashcardsHistory, setFlashcardsHistory] = useState<FlashcardsRecord[]>([]);
   // Sidebar combined history (paginated)
@@ -220,6 +223,7 @@ export default function DashboardClient() {
   const [shareError, setShareError] = useState<string | null>(null);
   const [shareLoading, setShareLoading] = useState(false);
   const [shareCopied, setShareCopied] = useState(false);
+  const [isSharePortalReady, setIsSharePortalReady] = useState(false);
   const [isReferralOpen, setIsReferralOpen] = useState(false);
   const [referralLink, setReferralLink] = useState<string | null>(null);
   const [referralCode, setReferralCode] = useState<string | null>(null);
@@ -241,6 +245,10 @@ export default function DashboardClient() {
   const referralRewardTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const shareLinksCacheRef = useRef<Map<string, string>>(new Map());
   const lastUpgradeTriggerRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    setIsSharePortalReady(true);
+  }, []);
 
   const displayName = getDisplayName(user);
   const displayInitials = getInitials(displayName);
@@ -904,7 +912,14 @@ export default function DashboardClient() {
             .select()
             .single();
 
+          setActiveMindMapId(null);
+          setActiveMindMapTitle(null);
+
           if (!insertError && insertData) {
+            const insertedId = typeof insertData.id === 'string' ? insertData.id : null;
+            const insertedTitle = typeof insertData.title === 'string' ? insertData.title : null;
+            setActiveMindMapId(insertedId);
+            setActiveMindMapTitle(insertedTitle);
             // Open the newly saved mind map for a seamless UX
             setMarkdown(pendingMarkdown);
             // Reload sidebar history to show the new item
@@ -1506,10 +1521,16 @@ export default function DashboardClient() {
         setCombinedHistory((prev) =>
           prev.map((item) => (item.id === itemId ? { ...item, title: newTitle } : item))
         );
+        if (itemType === 'mindmap' && itemId === activeMindMapId) {
+          setActiveMindMapTitle(newTitle);
+        }
         if (itemType === 'flashcards') {
           setFlashcardsHistory((prev) =>
             prev.map((item) => (item.id === itemId ? { ...item, title: newTitle } : item))
           );
+          if (itemId === activeDeckId) {
+            setFlashcardsTitle(newTitle);
+          }
         }
     }
     setRenamingItem(null);
@@ -1627,6 +1648,8 @@ export default function DashboardClient() {
                         item_id: item.id,
                       });
                       if (item.type === 'mindmap') {
+                        setActiveMindMapId(item.id);
+                        setActiveMindMapTitle(item.title ?? null);
                         setMarkdown(item.markdown);
                       } else {
                         setFlashcardsTitle(item.title || 'flashcards');
@@ -1909,14 +1932,25 @@ export default function DashboardClient() {
         </div>
       </main>
 
-      <MindMapModal markdown={markdown} onClose={() => setMarkdown(null)} />
+      <MindMapModal
+        markdown={markdown}
+        onClose={() => {
+          setMarkdown(null);
+          setActiveMindMapId(null);
+          setActiveMindMapTitle(null);
+        }}
+        onShareMindMap={activeMindMapId ? () => setShareItem({ id: activeMindMapId, type: 'mindmap', title: activeMindMapTitle ?? null }) : undefined}
+        onShareFlashcards={(deckId, title) => {
+          setShareItem({ id: deckId, type: 'flashcards', title });
+        }}
+      />
       <FlashcardsModal
         open={flashcardsOpen}
         title={flashcardsTitle}
         cards={flashcardsCards}
         isGenerating={false}
         error={flashcardsError}
-        onClose={() => { setFlashcardsOpen(false); setFlashcardsCards(null); setFlashcardsError(null); setStudyDueOnly(false); setStudyInterleaved(false); setDueIndices(undefined); setInitialDueIndex(undefined); }}
+        onClose={() => { setFlashcardsOpen(false); setFlashcardsCards(null); setFlashcardsError(null); setStudyDueOnly(false); setStudyInterleaved(false); setDueIndices(undefined); setInitialDueIndex(undefined); setActiveDeckId(undefined); }}
         onReviewDueCards={(indices) => {
           if (!indices || indices.length === 0) {
             return;
@@ -1932,6 +1966,7 @@ export default function DashboardClient() {
         interleavedDecks={studyInterleaved ? dueQueue : undefined}
         dueIndices={dueIndices}
         initialIndex={initialDueIndex}
+        onShare={activeDeckId && activeDeckId !== 'interleaved-session' ? () => setShareItem({ id: activeDeckId, type: 'flashcards', title: flashcardsTitle ?? null }) : undefined}
       />
       <PricingModal
         isOpen={isPricingModalOpen}
@@ -2288,60 +2323,74 @@ export default function DashboardClient() {
         </div>
       )}
 
-      {shareItem && (
-        <div className="fixed inset-0 bg-black/40 dark:bg-black/60 z-50 flex items-center justify-center p-4" onClick={() => setShareItem(null)}>
-          <div className="relative bg-background rounded-[1.5rem] p-6 w-full max-w-md border" onClick={(e) => e.stopPropagation()}>
-            <button onClick={() => setShareItem(null)} className="absolute top-4 right-4 inline-flex items-center justify-center w-8 h-8 rounded-full border border-border hover:bg-muted/60">
-              <X className="h-4 w-4" />
-            </button>
-            <div className="mb-1">
-              <h2 className="text-lg font-bold">Share public link to {shareItem.type === 'mindmap' ? 'Mind Map' : 'Flashcards'}</h2>
-            </div>
-            <p className="text-xs text-muted-foreground mb-4">Anyone with the link can view this {shareItem.type === 'mindmap' ? 'mind map' : 'flashcard deck'}.</p>
-            {shareError && (
-              <div className="mb-3 text-sm text-red-600">{shareError}</div>
-            )}
-            <div className="space-y-3">
-              <div className="flex rounded-full border border-border/40 bg-background shadow-inner focus-within:outline-none focus-within:ring-2 focus-within:ring-primary/40">
-                <input
-                  ref={shareLinkInputRef}
-                  value={shareLink ?? ''}
-                  readOnly
-                  placeholder="https://cogniguide.app/share/…"
-                  className="flex-1 bg-transparent px-4 py-3 text-sm font-medium text-foreground border-none outline-none focus:ring-0"
-                />
+      {shareItem && isSharePortalReady && typeof document !== 'undefined'
+        ? createPortal(
+            <div
+              className="fixed inset-0 bg-black/40 dark:bg-black/60 z-[1000] flex items-center justify-center p-4"
+              onClick={() => setShareItem(null)}
+            >
+              <div
+                className="relative bg-background rounded-[1.5rem] p-6 w-full max-w-md border"
+                onClick={(e) => e.stopPropagation()}
+              >
                 <button
-                  type="button"
-                  onClick={handleShareButtonClick}
-                  disabled={shareLoading}
-                  className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50 mr-1 my-1"
+                  onClick={() => setShareItem(null)}
+                  className="absolute top-4 right-4 inline-flex items-center justify-center w-8 h-8 rounded-full border border-border hover:bg-muted/60"
                 >
-                  {shareLoading ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : shareLink ? (
-                    shareCopied ? (
-                      <Check className="h-4 w-4" />
-                    ) : (
-                      <Copy className="h-4 w-4" />
-                    )
-                  ) : (
-                    <Link2 className="h-4 w-4" />
-                  )}
-                  <span>
-                    {shareLoading
-                      ? 'Creating…'
-                      : shareLink
-                        ? shareCopied
-                          ? 'Copied!'
-                          : 'Copy link'
-                        : 'Create link'}
-                  </span>
+                  <X className="h-4 w-4" />
                 </button>
+                <div className="mb-1">
+                  <h2 className="text-lg font-bold">
+                    Share public link to {shareItem.type === 'mindmap' ? 'Mind Map' : 'Flashcards'}
+                  </h2>
+                </div>
+                <p className="text-xs text-muted-foreground mb-4">
+                  Anyone with the link can view this {shareItem.type === 'mindmap' ? 'mind map' : 'flashcard deck'}.
+                </p>
+                {shareError && <div className="mb-3 text-sm text-red-600">{shareError}</div>}
+                <div className="space-y-3">
+                  <div className="flex rounded-full border border-border/40 bg-background shadow-inner focus-within:outline-none focus-within:ring-2 focus-within:ring-primary/40">
+                    <input
+                      ref={shareLinkInputRef}
+                      value={shareLink ?? ''}
+                      readOnly
+                      placeholder="https://cogniguide.app/share/…"
+                      className="flex-1 bg-transparent px-4 py-3 text-sm font-medium text-foreground border-none outline-none focus:ring-0"
+                    />
+                    <button
+                      type="button"
+                      onClick={handleShareButtonClick}
+                      disabled={shareLoading}
+                      className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50 mr-1 my-1"
+                    >
+                      {shareLoading ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : shareLink ? (
+                        shareCopied ? (
+                          <Check className="h-4 w-4" />
+                        ) : (
+                          <Copy className="h-4 w-4" />
+                        )
+                      ) : (
+                        <Link2 className="h-4 w-4" />
+                      )}
+                      <span>
+                        {shareLoading
+                          ? 'Creating…'
+                          : shareLink
+                            ? shareCopied
+                              ? 'Copied!'
+                              : 'Copy link'
+                            : 'Create link'}
+                      </span>
+                    </button>
+                  </div>
+                </div>
               </div>
-            </div>
-          </div>
-        </div>
-      )}
+            </div>,
+            document.body
+          )
+        : null}
     </div>
   );
 }

--- a/components/FlashcardsModal.tsx
+++ b/components/FlashcardsModal.tsx
@@ -13,6 +13,7 @@ import posthog from 'posthog-js';
 import { DatePicker } from '@/components/DatePicker';
 import { formatDate, formatTime } from '@/lib/utils';
 import { ensureKatexAssets } from '@/lib/katex-loader';
+import ShareTriggerButton from '@/components/ShareTriggerButton';
 
 const getDeckIdentifier = (deckId?: string, title?: string | null, cards?: Flashcard[] | null): string | null => {
   if (deckId) return deckId;
@@ -99,9 +100,10 @@ type Props = {
   interleavedDecks?: Array<{ id: string; title: string | null; cards: Flashcard[] }>;
   dueIndices?: number[];
   isEmbedded?: boolean;
+  onShare?: () => void;
 };
 
-export default function FlashcardsModal({ open, title, cards, isGenerating = false, error, onClose, onReviewDueCards, deckId, initialIndex, studyDueOnly = false, studyInterleaved = false, interleavedDecks, dueIndices, isEmbedded = false }: Props) {
+export default function FlashcardsModal({ open, title, cards, isGenerating = false, error, onClose, onReviewDueCards, deckId, initialIndex, studyDueOnly = false, studyInterleaved = false, interleavedDecks, dueIndices, isEmbedded = false, onShare }: Props) {
   const [index, setIndex] = React.useState(0);
   const [showAnswer, setShowAnswer] = React.useState(false);
   const [scheduledCards, setScheduledCards] = React.useState<CardWithSchedule[] | null>(null);
@@ -639,7 +641,10 @@ export default function FlashcardsModal({ open, title, cards, isGenerating = fal
           : 'bg-background border border-border ring-1 ring-black/5 shadow-2xl'
       }`}>
       {!isEmbedded && (
-        <div className="absolute top-2 right-2 z-30">
+        <div className="absolute top-2 right-2 z-30 flex items-center gap-2">
+          {onShare && (
+            <ShareTriggerButton onClick={onShare} />
+          )}
           <button
             onClick={handleClose}
             className="inline-flex items-center justify-center w-8 h-8 bg-background text-foreground rounded-full border border-border shadow-sm hover:bg-muted/50 dark:hover:bg-muted/80 focus:outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400/50"

--- a/components/MindMapModal.tsx
+++ b/components/MindMapModal.tsx
@@ -6,6 +6,7 @@ import { ensureKatexAssets } from '@/lib/katex-loader';
 import { Download, X, FileImage, Loader2, Map as MapIcon } from 'lucide-react';
 import FlashcardIcon from '@/components/FlashcardIcon';
 import FlashcardsModal from '@/components/FlashcardsModal';
+import ShareTriggerButton from '@/components/ShareTriggerButton';
 import { toSvg, toPng } from 'html-to-image';
 import { supabase } from '@/lib/supabaseClient';
 import { loadDeckSchedule, saveDeckSchedule, loadDeckScheduleAsync, saveDeckScheduleAsync } from '@/lib/sr-store';
@@ -16,10 +17,12 @@ import jsPDF from 'jspdf';
 interface MindMapModalProps {
   markdown: string | null;
   onClose: () => void;
+  onShareMindMap?: () => void;
+  onShareFlashcards?: (deckId: string, title: string | null) => void;
 }
 
 
-export default function MindMapModal({ markdown, onClose }: MindMapModalProps) {
+export default function MindMapModal({ markdown, onClose, onShareMindMap, onShareFlashcards }: MindMapModalProps) {
   const viewportRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [isDropdownOpen, setDropdownOpen] = useState(false);
@@ -1016,9 +1019,9 @@ export default function MindMapModal({ markdown, onClose }: MindMapModalProps) {
       <div className="fixed inset-0 backdrop-blur-sm flex items-center justify-center z-[100] p-4 font-sans" style={{ backgroundColor: 'var(--color-background)' }}>
         <div className="relative w-full h-full rounded-[1.5rem] border border-border ring-1 ring-black/5 shadow-2xl shadow-[0_10px_25px_rgba(0,0,0,0.12),0_25px_70px_rgba(0,0,0,0.18)] flex flex-col overflow-hidden" style={{ backgroundColor: 'var(--color-background)' }}>
           <div className="absolute top-2 right-2 z-30 group inline-flex items-center gap-1.5">
-              {viewMode === 'map' ? (
-                <>
-                  <button
+            {viewMode === 'map' ? (
+              <>
+                <button
                     onClick={flashcards ? () => setViewMode('flashcards') : handleGenerateFlashcards}
                     className={`inline-flex items-center gap-1 px-4 py-1.5 rounded-full border border-border text-foreground hover:bg-muted/50 text-sm focus:outline-none min-w-[44px] transition-all duration-300 ease-in-out ${
                       isGeneratingFlashcards
@@ -1102,14 +1105,21 @@ export default function MindMapModal({ markdown, onClose }: MindMapModalProps) {
                 </>
               )}
 
-              <button
-                onClick={handleClose}
-                className="inline-flex items-center justify-center w-8 h-8 text-foreground rounded-full border border-border shadow-sm hover:bg-muted/50 focus:outline-none opacity-100 translate-x-0 transition-all duration-200 ease-in-out"
-                style={{ backgroundColor: 'var(--color-background)' }}
-                aria-label="Close"
-              >
-                <X className="h-4 w-4" />
-              </button>
+            {onShareMindMap && (
+              <ShareTriggerButton
+                onClick={onShareMindMap}
+                className="opacity-100 translate-x-0 transition-all duration-200 ease-in-out"
+              />
+            )}
+
+            <button
+              onClick={handleClose}
+              className="inline-flex items-center justify-center w-8 h-8 text-foreground rounded-full border border-border shadow-sm hover:bg-muted/50 focus:outline-none opacity-100 translate-x-0 transition-all duration-200 ease-in-out"
+              style={{ backgroundColor: 'var(--color-background)' }}
+              aria-label="Close"
+            >
+              <X className="h-4 w-4" />
+            </button>
           </div>
 
           {/* White overlay to fully cover mind map when in flashcards mode */}
@@ -1135,6 +1145,7 @@ export default function MindMapModal({ markdown, onClose }: MindMapModalProps) {
                 onClose={() => setViewMode('map')}
                 deckId={flashcardsSavedId || undefined}
                 initialIndex={flashcardIndex}
+                onShare={flashcardsSavedId && onShareFlashcards ? () => onShareFlashcards(flashcardsSavedId, getTitle(markdown) || null) : undefined}
               />
             )}
           </div>

--- a/components/ShareTriggerButton.tsx
+++ b/components/ShareTriggerButton.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import * as React from 'react';
+import { Share2 } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+export type ShareTriggerButtonProps = Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'children'> & {
+  srLabel?: string;
+};
+
+export default function ShareTriggerButton({ srLabel = 'Share', className, type, ...props }: ShareTriggerButtonProps) {
+  return (
+    <button
+      type={type ?? 'button'}
+      aria-label={props['aria-label'] ?? srLabel}
+      {...props}
+      className={cn(
+        'inline-flex h-8 w-8 items-center justify-center rounded-full border border-border bg-background text-foreground shadow-sm transition-colors hover:bg-muted/50 focus:outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400/50 disabled:pointer-events-none disabled:opacity-50',
+        className,
+      )}
+    >
+      <Share2 className="h-4 w-4" />
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- track the active mind map metadata in the dashboard so share links can be generated from the modal
- add a reusable share trigger button and surface share controls beside the close buttons in the flashcards and mind map modals
- ensure the share modal overlay appears above the flashcards and mind map modals by rendering it through a high-z-index portal

## Testing
- pnpm exec eslint app/dashboard/DashboardClient.tsx *(fails: existing lint violations in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68e461b5a23c832580fbfbee081cd6c5